### PR TITLE
Add source_id parameter

### DIFF
--- a/aws/sam.yml
+++ b/aws/sam.yml
@@ -17,6 +17,9 @@ Parameters:
   TimberAPIKey:
     Type: String
     Description: Your Timber.io API key. If you don't have a key, you can easily create one at https://app.timber.io.
+  TimberSourceID:
+    Type: String
+    Description: Your Timber.io source ID key. This is displayed on your source's installation page.
 Resources:
   TimberLoggingFunction:
     Type: 'AWS::Serverless::Function'
@@ -29,6 +32,8 @@ Resources:
       Timeout: 30
       Environment:
         Variables:
+          TIMBER_SOURCE_ID:
+            Ref: TimberSourceID
           TIMBER_API_KEY:
             Ref: TimberAPIKey
 Outputs:

--- a/main.py
+++ b/main.py
@@ -14,7 +14,8 @@ if os.path.exists(version_file):
         version = version_file.read().strip()
 
 API_KEY = os.environ['TIMBER_API_KEY']
-URL = os.getenv('TIMBER_URL', 'https://logs.timber.io/frames')
+SOURCE_ID = os.environ['TIMBER_SOURCE_ID']
+HOST = os.getenv('TIMBER_HOST', 'https://logs.timber.io')
 HEADERS_PROTOTYPE = {
     'Content-Type': 'text/plain',
     'User-Agent': f'Timber Cloudwatch Lambda Function/{version} (python)'
@@ -81,10 +82,11 @@ def deliver(log_lines):
     authorization_token = base64.b64encode(API_KEY.encode()).decode()
 
     headers = HEADERS_PROTOTYPE.copy()
-    headers['Authorization'] = 'Basic ' + authorization_token
+    headers['Authorization'] = 'Bearer ' + authorization_token
     headers['Content-Length'] = len(body_bytes)
 
-    request = Request(URL, data=body_bytes, headers=headers)
+    url = str(HOST) + '/sources/' + str(SOURCE_ID)
+    request = Request(url, data=body_bytes, headers=headers)
 
     code = urlopener.open(request).read()
 


### PR DESCRIPTION
This change updates the lambda function to use the new API keys. The new API keys are organization specific, not source specific, therefore a source ID must be specified.